### PR TITLE
Regexp compatibility with older Firefox versions

### DIFF
--- a/res/static/js/main.js
+++ b/res/static/js/main.js
@@ -181,7 +181,7 @@ function 请求语言包(code) {
   //请求页面语言包
   let pageName;
   if (window.location.href.match("html")) {
-    pageName = window.location.href.match(/(?<=\/)[^\/]+(?=\.html)/gi)[0];
+    pageName = window.location.href.match(/(?=[^\/]+)\w+(?=\.html)/gi)[0];
   } else {
     pageName = "index";
   }


### PR DESCRIPTION
Older versions of Firefox (e.g. FF 65) cannot deal with regular expressions like "(?<=)" correctly. We may replace them with traditional regexp syntax "(?=)" for compatibility.